### PR TITLE
fixes fragment shader compilation error

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -140,9 +140,11 @@ impl<'a> Renderer<'a> {
 
             uniform sampler2D tex;
 
+            out vec4 frag_color;
+
             void main() {
-                gl_FragColor = texture2D(tex, v_tex_coords);
-                gl_FragColor.a = alpha;
+                frag_color = texture(tex, v_tex_coords);
+                frag_color.a = alpha;
             }
         "#;
 


### PR DESCRIPTION
On
    OSX 10.10.4
    ATI Radeon HD 6750M
    OpenGL 4.1
    OpenCL 1.2

texture2D and gl_FragColor were causing compilation errors

_Only_ tested in on the above platform.
